### PR TITLE
Fix three typos in the TruePrims algorithm

### DIFF
--- a/src/algorithms/TruePrims.js
+++ b/src/algorithms/TruePrims.js
@@ -34,6 +34,7 @@ class TruePrims extends Algorithm {
       }
     }
 
+    this.totalVisted = 0;
     this.activePassages = [];
 
     let startCell = {
@@ -69,6 +70,7 @@ class TruePrims extends Algorithm {
     if (this.cellIsInMaze(newCell) && !this.visited[newCell.y][newCell.x] > 0) {
       this.removeWall({ x: passage.x, y: passage.y }, passage.direction);
       this.visited[newCell.y][newCell.x] = true;
+      this.totalVisted++;
 
       for (let direction of directions) {
         if (direction !== opposite[passage.direction]) {

--- a/src/algorithms/TruePrims.js
+++ b/src/algorithms/TruePrims.js
@@ -22,7 +22,7 @@ class TruePrims extends Algorithm {
           let passageCost = isBorderWall ? Infinity : this.random();
 
           if ((direction === "N" || direction === "W") && !isBorderWall) {
-            passageCost ==
+            passageCost =
               this
                 .costs[y + dy[direction]][x + dx[direction]][
                 opposite[direction]
@@ -33,7 +33,6 @@ class TruePrims extends Algorithm {
         }
       }
     }
-    this.totalVisted = 0;
 
     this.activePassages = [];
 
@@ -70,7 +69,6 @@ class TruePrims extends Algorithm {
     if (this.cellIsInMaze(newCell) && !this.visited[newCell.y][newCell.x] > 0) {
       this.removeWall({ x: passage.x, y: passage.y }, passage.direction);
       this.visited[newCell.y][newCell.x] = true;
-      this.totalVisted++;
 
       for (let direction of directions) {
         if (direction !== opposite[passage.direction]) {

--- a/src/algorithms/TruePrims.js
+++ b/src/algorithms/TruePrims.js
@@ -34,7 +34,7 @@ class TruePrims extends Algorithm {
       }
     }
 
-    this.totalVisted = 0;
+    this.totalVisited = 0;
     this.activePassages = [];
 
     let startCell = {
@@ -70,7 +70,7 @@ class TruePrims extends Algorithm {
     if (this.cellIsInMaze(newCell) && !this.visited[newCell.y][newCell.x] > 0) {
       this.removeWall({ x: passage.x, y: passage.y }, passage.direction);
       this.visited[newCell.y][newCell.x] = true;
-      this.totalVisted++;
+      this.totalVisited++;
 
       for (let direction of directions) {
         if (direction !== opposite[passage.direction]) {


### PR DESCRIPTION
Eliminated the miss-spelled totalVisted - it is never read.
Corrected the '==' (compare) to '=' (assign) when deriving passage costs.